### PR TITLE
Fix setup on OS X.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,7 @@ pip install pyZZUF
 pip install adb_android
 
 #folders for the fuzzer
-mkdir $HOME"/myfuzzer/fuzzer/confirmed_crashes/"
-mkdir $HOME"/myfuzzer/fuzzer/crashes/"
-mkdir $HOME"/myfuzzer/fuzzer/generated_samples_folder/"
+mkdir -p $HOME"/myfuzzer/fuzzer"
+mkdir -p $HOME"/myfuzzer/fuzzer/confirmed_crashes/"
+mkdir -p $HOME"/myfuzzer/fuzzer/crashes/"
+mkdir -p $HOME"/myfuzzer/fuzzer/generated_samples_folder/"


### PR DESCRIPTION
When running setup on osx, I got:

``` bash
mkdir: /Users/XXXXX/myfuzzer/fuzzer: No such file or directory
mkdir: /Users/XXXXX/myfuzzer/fuzzer: No such file or directory
mkdir: /Users/XXXXX/myfuzzer/fuzzer: No such file or directory
```
